### PR TITLE
進捗バーの仮作成

### DIFF
--- a/FallingSlime/Content/FallingSlime/Stage/Blueprints/BP_StageGameMode.uasset
+++ b/FallingSlime/Content/FallingSlime/Stage/Blueprints/BP_StageGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee77e41517778e60924e1ffd6656dfe5a5061bb434b54cde16753454a0ea714f
-size 485266
+oid sha256:39952ebce7cc4e88ad4708af3abf0c0818db38081117e257a49cf1b3d5e783c3
+size 489373

--- a/FallingSlime/Content/FallingSlime/UI/Hud/WBP_StageLengthView.uasset
+++ b/FallingSlime/Content/FallingSlime/UI/Hud/WBP_StageLengthView.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53a757369dbc31e192b19ba0b9ba9c47e11a41659dbc1ae6cc6be197896e231c
+size 118271


### PR DESCRIPTION
いったんバーが動くところの実装終了。
・プレイヤーのスタート地点のうち0番（初期スタート）と一番深いゴール地点を上と下として、現在位置をごりごり計算する感じ。 ・テクスチャ周りはできてない。
・位置調整もできてない。