### PR TITLE
進捗バーをアイコン移動式に変更

### DIFF
--- a/FallingSlime/Content/FallingSlime/UI/Hud/WBP_StageLengthView.uasset
+++ b/FallingSlime/Content/FallingSlime/UI/Hud/WBP_StageLengthView.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53a757369dbc31e192b19ba0b9ba9c47e11a41659dbc1ae6cc6be197896e231c
-size 118271
+oid sha256:321ec8ee45b1438275e2f00e65c9da085282d2dd0f97d2e3ebea6900182ab897
+size 171472


### PR DESCRIPTION
中間地点の表示は未実装。
サイズ変更はしても大丈夫だと思う（未確認）
ScaleBoxがサイズ認識で悪さをするのでWBPに直置きする形になっている。